### PR TITLE
Add context menu multi-selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
   "contributes": {
     "commands": [
       {
-        "command": "markfiles.markUnmarkFile",
+        "command": "markfiles.markUnmarkSelectedFile",
+        "title": "Mark/Unmark selected file(s)"
+      },
+      {
+        "command": "markfiles.markUnmarkActiveFile",
         "title": "Mark/Unmark current file"
       },
       {
@@ -29,11 +33,11 @@
     ], 
     "menus": {
       "explorer/context": [{
-          "command": "markfiles.markUnmarkFile",
-          "group": "Mark/Unmark file"
+        "command": "markfiles.markUnmarkSelectedFile",
+        "group": "Mark/Unmark file"
       }],
       "editor/title/context": [{
-        "command": "markfiles.markUnmarkFile",
+        "command": "markfiles.markUnmarkActiveFile",
         "group": "Mark/Unmark file"
       }]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,25 +11,43 @@ export function activate(context: vscode.ExtensionContext) {
 	let disposable = vscode.window.registerFileDecorationProvider(provider);
 	context.subscriptions.push(disposable);
 
-	disposable = vscode.commands.registerCommand('markfiles.markUnmarkFile', async (contextUri: vscode.Uri) => {
-		const uri = contextUri || vscode.window.activeTextEditor?.document.uri;
-		if (uri) {
-			const stat = await vscode.workspace.fs.stat(uri);
-			if (stat.type !== vscode.FileType.File) {return;} //can't mark directory
-			if (provider.markedFiles.has(uri.fsPath)) {
-				provider.update([], [uri.fsPath]);
-			} else {
-				provider.update([uri.fsPath], []);
-			}
-		} 
-	});
-	context.subscriptions.push(disposable);
+	context.subscriptions.push(
+		vscode.commands.registerCommand('markfiles.markUnmarkActiveFile', async (contextUri: vscode.Uri) => {
+			const uri = vscode.window.activeTextEditor?.document.uri;
+			if (uri) {
+				const stat = await vscode.workspace.fs.stat(uri);
+				if (stat.type !== vscode.FileType.File) {return;} //can't mark directory
+				if (provider.markedFiles.has(uri.fsPath)) {
+					provider.update([], [uri.fsPath]);
+				} else {
+					provider.update([uri.fsPath], []);
+				}
+			} 
+		})
+	);
 
-	disposable = vscode.commands.registerCommand('markfiles.reloadFromScopeFile', async () => {
-		provider.loadFromScopeFile(true);
-		vscode.window.showInformationMessage('Loading marked files from scope file(s)');
-	});
-	context.subscriptions.push(disposable);
+	context.subscriptions.push(
+		vscode.commands.registerCommand('markfiles.markUnmarkSelectedFile', async (clickedFile: vscode.Uri, selectedFiles: vscode.Uri[]) => {
+			for (const uri of selectedFiles) {
+				if (uri) {
+					const stat = await vscode.workspace.fs.stat(uri);
+					if (stat.type !== vscode.FileType.File) {continue;} //can't mark directory
+					if (provider.markedFiles.has(uri.fsPath)) {
+						provider.update([], [uri.fsPath]);
+					} else {
+						provider.update([uri.fsPath], []);
+					}
+				} 
+			}
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('markfiles.reloadFromScopeFile', async () => {
+			provider.loadFromScopeFile(true);
+			vscode.window.showInformationMessage('Loading marked files from scope file(s)');
+		})
+	);
 
 	//listen to configuration changes
 	vscode.workspace.onDidChangeConfiguration((e) => {


### PR DESCRIPTION
Adds ability to select multiple files from the context menu at once to mark them all in scope.

I split the command into two, one for the context menu and one for the current file. I think it's a little cleaner this way, let me know what you think.


https://user-images.githubusercontent.com/8558782/225162216-549f0d76-d143-44af-ac12-97e45f5c8794.mov